### PR TITLE
Fix log string in DataShare

### DIFF
--- a/src/com/DataShare.js
+++ b/src/com/DataShare.js
@@ -31,7 +31,7 @@ export default function DataShare() {
   const handleSendMessage = () => {
     const payload = {events, people, prayers, topics}
     
-    console.log('seding', payload)
+    console.log('sending', payload)
     sendMessage(payload)
   }
   


### PR DESCRIPTION
## Summary
- fix typo in `DataShare` console output

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*