### PR TITLE
Fix chordset visibility and chord positioning

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,14 +113,16 @@ button:active {
 
 
 .chord {
-  position: relative;
-  top: -0.5em;
   font-weight: bold;
   color: #3a86ff;
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0.2em;
-  vertical-align: baseline;
+  vertical-align: super;
+}
+
+.song-chords {
+  display: none;
 }
 
 .lyric-line {

--- a/src/com/View/View.js
+++ b/src/com/View/View.js
@@ -21,6 +21,10 @@ export default function View() {
   const [html, setHtml] = useState(null)
   const [showEdit, setShowEdit] = useState(false)
 
+  useEffect(() => {
+    setShowChordset(false)
+  }, [])
+
 
   useEffect(() => {
     const thisItem = list.find(item => item.id === query.id)


### PR DESCRIPTION
## Summary
- ensure chordset section is hidden by default
- keep chordset preference from persisting across sessions
- style chord elements so they don't overlap previous lines

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*