### PR TITLE
Add set viewer and reordering

### DIFF
--- a/src/com/Set/Display.js
+++ b/src/com/Set/Display.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import useLocalStorage from '../../hook/useLocalStorage'
+import { KEY } from '../../constants'
+
+export default function Display({ setId }) {
+  const [songs] = useLocalStorage(KEY.LIST, [])
+  const [sets] = useLocalStorage(KEY.SETS, [])
+
+  const set = sets.find(s => s.id === setId)
+
+  return (
+    <div>
+      <h2>Set: {set?.name}</h2>
+      <p>{set?.datetime}</p>
+      <ol className='song list'>
+        {set?.songs?.map((entry, i) => {
+          const song = songs.find(s => s.id === entry.songId)
+          return (
+            <li key={i}>
+              <a href={`?id=${song?.id}#view`}>{song?.name}</a>
+              {entry.arrangement ? ` (${entry.arrangement})` : ''}
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/src/com/Set/View.js
+++ b/src/com/Set/View.js
@@ -34,6 +34,15 @@ export default function View({setId}) {
     updateSet({ ...selectedSet, songs: newSongs })
   }
 
+  const moveSong = (index, delta) => {
+    const newIndex = index + delta
+    if (newIndex < 0 || newIndex >= selectedSet.songs.length) return
+    const newSongs = [...selectedSet.songs]
+    const [item] = newSongs.splice(index, 1)
+    newSongs.splice(newIndex, 0, item)
+    updateSet({ ...selectedSet, songs: newSongs })
+  }
+
   const updateArrangement = (id, arrangement) => {
     const newSongs = selectedSet.songs.map(s =>
       s.songId === id ? { ...s, arrangement } : s
@@ -58,7 +67,7 @@ export default function View({setId}) {
     }
   }, [songToAdd])
 
-  function SetSong({entry}) {
+  function SetSong({entry, index}) {
     const song = songs.find(song => song.id === entry.songId)
     const [opts, setOpts] = useState([])
 
@@ -70,6 +79,8 @@ export default function View({setId}) {
     }, [song])
 
     return <li>
+      <button onClick={() => moveSong(index, -1)} disabled={index===0}>▲</button>
+      <button onClick={() => moveSong(index, 1)} disabled={index===selectedSet.songs.length-1}>▼</button>
       {song?.name}
       <select value={entry.arrangement || ''} onChange={e => updateArrangement(entry.songId, e.target.value)}>
         <option value=''>default</option>
@@ -88,7 +99,7 @@ export default function View({setId}) {
 
     <p>Songs in this set:</p>
     <ul className='song list'>
-      {selectedSet?.songs?.map((entry, i) => <SetSong key={i} entry={entry} />)}
+      {selectedSet?.songs?.map((entry, i) => <SetSong key={i} entry={entry} index={i} />)}
     </ul>
 
     <div>

--- a/src/com/Set/index.js
+++ b/src/com/Set/index.js
@@ -1,14 +1,17 @@
 import React, {useState} from 'react'
 import useLocalStorage from '../../hook/useLocalStorage'
+import useURL from '../../hook/useURL'
 import {KEY} from '../../constants'
 import {v4 as uuid} from 'uuid'
 import View from './View'
+import Display from './Display'
 import Icon from 'unicode-icons'
 
 
 export default function Set() {
+  const {query} = useURL()
   const [sets, setSets] = useLocalStorage(KEY.SETS, [])
-  
+
   const [selectedSetId, setSelectedSetId] = useState(null)
   
 
@@ -38,7 +41,11 @@ export default function Set() {
     }
   }
 
-  
+
+  if (query?.id) {
+    return <Display setId={query.id} />
+  }
+
   return <>
     <h2>Sets</h2>
     <p>A set is a collection of songs that are played together.</p>
@@ -51,7 +58,8 @@ export default function Set() {
     <ul className='song list'>
       {Array.isArray(sets) && sets.map((set, index) => (
         <li key={index}>
-          <button onClick={() => setSelectedSetId(set.id)}>{set.name}</button>
+          <a href={`?id=${set.id}#set`}>{set.name}</a>
+          <button onClick={() => setSelectedSetId(set.id)}>{Icon.PENCIL}</button>
           <button onClick={() => remove(set.id)}>{Icon.RED_X}</button>
         </li>
       ))}


### PR DESCRIPTION
## Summary
- add a simple display component for sets
- open `?id=XXX#set` as view-only set display
- link set names to the new view from the set list
- allow reordering songs within the set editor

## Testing
- `npm test --silent` *(fails: react-scripts not found)*