### PR TITLE
Improve look with accent color

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,9 @@
 header {
   position: relative;
   width: 100%;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-background);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 main {
@@ -38,6 +41,9 @@ footer {
   align-items: center;
   justify-content: space-evenly;
   gap: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-background);
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
 }
 
 
@@ -55,20 +61,24 @@ a {
   border: medium outset var(--color-secondary-transparent);
   border-radius: 0.66rem;
   margin: 0.1rem;
-  padding: 0.1rem;
-  font-size: 1.5rem;
+  padding: 0.1rem 0.4rem;
+  font-size: 1.25rem;
   cursor: pointer;
   background-color: var(--color-background);
   text-decoration: none;
+  color: var(--color-accent);
+  transition: background-color 0.1s ease;
 }
 
 a:hover {
   border-style: solid;
   background-color: var(--color-background-light);
+  color: var(--color-accent);
 }
 
 a:active {
   border-style: inset;
+  color: var(--color-accent);
 }
 
 
@@ -77,18 +87,22 @@ button {
   border: medium outset var(--color-secondary-transparent);
   border-radius: 0.66rem;
   padding: 0rem;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   cursor: pointer;
   background-color: var(--color-background);
+  color: var(--color-accent);
+  transition: background-color 0.1s ease;
 }
 
 button:hover {
   border-style: solid;
   background-color: var(--color-background-light);
+  color: var(--color-accent);
 }
 
 button:active {
   border-style: inset;
+  color: var(--color-accent);
 }
 
 
@@ -101,14 +115,17 @@ button:active {
   border: thick ridge var(--color-secondary-transparent);
   border-radius: 1rem;
   padding: 0;
+  color: var(--color-accent);
 }
 
 .back.button:hover {
   border-style: double;
+  color: var(--color-accent);
 }
 
 .back.button:active {
   border-style: groove;
+  color: var(--color-accent);
 }
 
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,15 @@
 :root {
-  --color-primary: hsl(34, 32%, 20%);
-  --color-primary-transparent: hsla(34, 32%, 20%, 0.5);
-  --color-secondary: hsl(34, 35%, 40%);
-  --color-secondary-transparent: hsla(34, 35%, 40%, 0.5);
-  --color-background: hsl(39, 46%, 90%);
-  --color-background-light: hsl(39, 46%, 95%);
-  --color-background-transparent: hsla(39, 46%, 90%, 0.5);
+  /* slightly darker text for better contrast and an accent color */
+  --color-primary: hsl(34, 32%, 15%);
+  --color-primary-transparent: hsla(34, 32%, 15%, 0.5);
+  --color-secondary: hsl(34, 35%, 35%);
+  --color-secondary-transparent: hsla(34, 35%, 35%, 0.5);
+  /* parchment background retained but lightened a bit */
+  --color-background: #f5efe4;
+  --color-background-light: #fbf8f2;
+  --color-background-transparent: rgba(245, 239, 228, 0.5);
+  /* accent similar to good.is */
+  --color-accent: #0066cc;
 }
 
 * {
@@ -18,9 +22,11 @@
 
 body {
   margin: 0;
-  font-family: 'Georgia', 'Times New Roman', Times, serif;
+  /* use a clean sans-serif stack similar to good.is */
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  line-height: 1.6;
 }
 
 code {


### PR DESCRIPTION
## Summary
- modernize look by lightening parchment colors
- switch to a clean sans-serif font stack
- add an accent color to links and buttons
- tweak header and footer with simple drop shadows

## Testing
- `npm test -- --watchAll=false` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477edc414083278e9d2436022471a7