### PR TITLE
Add drag-and-drop arrangement editor

### DIFF
--- a/src/com/Arrangement.js
+++ b/src/com/Arrangement.js
@@ -1,0 +1,86 @@
+import {useEffect, useState} from 'react'
+import styles from './Sections.module.css'
+import {parseSong} from '../lib/SongToHtml'
+
+function updateRaw(raw,{name,items}){
+  const lines=raw.replace(/\r\n?/g,'\n').split('\n')
+  const arrIdx=lines.findIndex(l=>/^\s*Arrangements:/i.test(l))
+  const head=/^\s{2,}([\w\d \-]+):/;
+  const newLines=items.map(s=>'    '+s)
+  if(arrIdx===-1){
+    return [...lines,'Arrangements:','  '+name+':',...newLines].join('\n')
+  }
+  let i=arrIdx+1
+  let hdrIdx=null
+  while(i<lines.length){
+    if(head.test(lines[i])){hdrIdx=i;break}
+    i++
+  }
+  if(hdrIdx===null){
+    lines.splice(arrIdx+1,0,'  '+name+':',...newLines)
+    return lines.join('\n')
+  }
+  lines[hdrIdx]='  '+name+':'
+  i=hdrIdx+1
+  while(i<lines.length && !head.test(lines[i])) lines.splice(i,1)
+  lines.splice(i,0,...newLines)
+  return lines.join('\n')
+}
+
+export default function Arrangement({raw,onChange}){
+  const [sections,setSections]=useState([])
+  const [arr,setArr]=useState({name:'',items:[]})
+  const [dragged,setDragged]=useState(null)
+
+  useEffect(()=>{
+    const {sections:secs,arrangements}=parseSong(raw)
+    setSections(secs)
+    const first=Object.keys(arrangements)[0]
+    setArr({name:first,items:arrangements[first]||[]})
+  },[raw])
+
+  const updateItems=(items)=>{
+    const updated={...arr,items}
+    setArr(updated)
+    onChange(updateRaw(raw,updated))
+  }
+
+  const handleDragStart=(e,i)=>{setDragged(i);e.dataTransfer.effectAllowed='move'}
+  const handleDragOver=(e,i)=>{
+    e.preventDefault()
+    if(dragged===null) return
+    const items=[...arr.items]
+    const [d]=items.splice(dragged,1)
+    items.splice(i,0,d)
+    setDragged(i)
+    updateItems(items)
+  }
+  const handleDragEnd=()=>setDragged(null)
+  const duplicate=(i)=>{const items=[...arr.items];items.splice(i+1,0,arr.items[i]);updateItems(items)}
+  const remove=(i)=>{updateItems(arr.items.filter((_,j)=>j!==i))}
+  const changeItem=(i,val)=>{const items=arr.items.map((s,j)=>j===i?val:s);updateItems(items)}
+  const addItem=()=>{updateItems([...arr.items,sections[0]||''])}
+
+  return <div className={styles.sections}>
+    <h2 className={styles.header}>Arrangement</h2>
+    <div className={styles.section}>
+      {arr.items.map((sec,i)=>(
+        <div key={i} className={`draggable ${dragged===i?'border-blue-500 bg-blue-50':''}`} draggable
+          onDragStart={e=>handleDragStart(e,i)}
+          onDragOver={e=>handleDragOver(e,i)}
+          onDragEnd={handleDragEnd}
+        >
+          <div className={styles.slug}>
+            <div className={styles.grip}>⠿</div>
+            <select className={styles.name} value={sec} onChange={e=>changeItem(i,e.target.value)}>
+              {sections.map((s,idx)=><option key={idx} value={s}>{s}</option>)}
+            </select>
+            <button className={styles.delete} type="button" onClick={()=>duplicate(i)}>⧉</button>
+            <button className={styles.delete} type="button" onClick={()=>remove(i)}>❌</button>
+          </div>
+        </div>
+      ))}
+    </div>
+    <button className={styles.add} type="button" onClick={addItem}>Add Item</button>
+  </div>
+}

--- a/src/com/Edit.js
+++ b/src/com/Edit.js
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react'
 import Sections from './Sections'
+import Arrangement from './Arrangement'
 import useLocalStorage from '../hook/useLocalStorage'
 import useURL from '../hook/useURL'
 import {KEY, STATE} from '../constants'
@@ -19,14 +20,14 @@ export default function Edit({className, itemId, setShowEdit}) {
     event.preventDefault()
     
     const formData = new FormData(event.target)
-    const id = formData.get('id')    
+    const id = formData.get('id')
     const name = formData.get('name')
     // const sections = JSON.parse(formData.get('sections'))
-    const raw = formData.get('raw')
+    const rawText = raw
     
     const newItem = {
       ...selection,
-      id, name, raw,
+      id, name, raw: rawText,
     }
     
     const newList = list.map(item => item.id === id ? newItem : item)
@@ -43,6 +44,7 @@ export default function Edit({className, itemId, setShowEdit}) {
   useEffect(() => {
     const thisItem = list.find(item => item.id === itemId)
     setSelection(thisItem)
+    setRaw(thisItem?.raw || '')
   }, [itemId])
   
   
@@ -56,7 +58,9 @@ export default function Edit({className, itemId, setShowEdit}) {
         
         {/* <Sections data={selection.sections} /> */}
 
-        <textarea name="raw" defaultValue={selection?.raw} />
+        <Arrangement raw={raw} onChange={setRaw} />
+
+        <textarea name="raw" value={raw} onChange={e=>setRaw(e.target.value)} />
         
         <button type="submit">Save</button>
       </form>

--- a/src/lib/SongToHtml.js
+++ b/src/lib/SongToHtml.js
@@ -10,6 +10,46 @@
 //     and all earlier fixes retained.
 // ---------------------------------------------------------------------------
 
+export function parseSong(source){
+  const lines=source.replace(/\r\n?/g,"\n").split("\n");
+  let idx=0;
+  const sectionHeader=/^\s{2,}([\w \-]+):\s*$/;
+  const sections=[];
+  while(idx<lines.length && !/^\s*Arrangements:/i.test(lines[idx])){
+    const m=lines[idx].match(sectionHeader);
+    if(m){
+      const name=m[1].trim();
+      sections.push(name);
+      idx++;
+      while(idx<lines.length &&
+            !sectionHeader.test(lines[idx]) &&
+            !/^\s*Arrangements:/i.test(lines[idx])) idx++; 
+    } else idx++; 
+  }
+
+  const arrangements={};
+  if(idx<lines.length && /^\s*Arrangements:/i.test(lines[idx])){
+    idx++;
+    const head=/^\s{2,}([\w \-]+):\s*$/;
+    while(idx<lines.length){
+      const mh=lines[idx].match(head);
+      if(mh){
+        const name=mh[1].trim();
+        idx++;
+        const items=[];
+        while(idx<lines.length && !head.test(lines[idx])){
+          if(lines[idx].trim()) items.push(lines[idx].trim());
+          idx++;
+        }
+        arrangements[name]=items;
+      } else idx++;
+    }
+  }
+  if(!Object.keys(arrangements).length) arrangements.default=sections;
+
+  return {sections, arrangements};
+}
+
 export default function songToHtml (source, arrangementName = "") {
   const lines = source.replace(/\r\n?/g, "\n").split("\n");
   let idx = 0;


### PR DESCRIPTION
## Summary
- expose `parseSong` in `SongToHtml` for section/arrangement parsing
- use `parseSong` in `Arrangement` component
- keep textarea controlled so arrangement edits update raw song text

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4e8426c83278c735c53557ff559