### PR TITLE
Add File API utilities and editor buttons

### DIFF
--- a/src/com/Edit.js
+++ b/src/com/Edit.js
@@ -4,6 +4,7 @@ import Arrangement from './Arrangement'
 import useLocalStorage from '../hook/useLocalStorage'
 import useURL from '../hook/useURL'
 import {KEY, STATE} from '../constants'
+import { downloadText, loadText } from '../lib/file'
 
 import style from './Edit.module.css'
 
@@ -61,8 +62,13 @@ export default function Edit({className, itemId, setShowEdit}) {
         <Arrangement raw={raw} onChange={setRaw} />
 
         <textarea name="raw" value={raw} onChange={e=>setRaw(e.target.value)} />
-        
+
         <button type="submit">Save</button>
+        <button type="button" onClick={() => downloadText(`${selection?.name || 'song'}.txt`, raw)}>Save File</button>
+        <button type="button" onClick={async () => {
+          const text = await loadText();
+          if (text !== null) setRaw(text);
+        }}>Load File</button>
       </form>
     </div>
   </div>

--- a/src/com/Set/View.js
+++ b/src/com/Set/View.js
@@ -3,6 +3,7 @@ import useLocalStorage from '../../hook/useLocalStorage'
 import {KEY} from '../../constants'
 import Icon from 'unicode-icons'
 import songToHtml from '../../lib/SongToHtml'
+import { downloadJSON, loadJSON } from '../../lib/file'
 
 
 export default function View({setId}) {
@@ -92,6 +93,13 @@ export default function View({setId}) {
 
   return <div>
     <h2>Set: {selectedSet?.name}</h2>
+    <div>
+      <button onClick={() => downloadJSON(`${selectedSet?.name || 'set'}.json`, selectedSet)}>Save Set</button>
+      <button onClick={async () => {
+        const data = await loadJSON();
+        if (data) updateSet({ ...selectedSet, ...data });
+      }}>Load Set</button>
+    </div>
     <label>
       Date/Time:
       <input type="datetime-local" value={selectedSet?.datetime || ''} onChange={e => updateSet({ ...selectedSet, datetime: e.target.value })} />

--- a/src/com/Song/Edit.js
+++ b/src/com/Song/Edit.js
@@ -3,6 +3,7 @@ import {KEY} from '../../constants'
 import {useHREF} from '../../lib/HREFContext'
 import Sections from './Sections'
 import useLocalStorage from '../../hook/useLocalStorage'
+import { downloadText, loadText } from '../../lib/file'
 
 
 export default function Edit() {
@@ -80,8 +81,13 @@ export default function Edit() {
       </label>
       
       <Sections data={sections} onChange={updateSections} />
-      
+
       <button>Save</button>
+      <button type="button" onClick={() => downloadText(`${song.name || 'song'}.txt`, song.raw || '')}>Save File</button>
+      <button type="button" onClick={async () => {
+        const text = await loadText();
+        if (text !== null) setSong({...song, raw: text});
+      }}>Load File</button>
     </form>
   </div>
 }

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -1,0 +1,57 @@
+export function downloadText(filename, text) {
+  const blob = new Blob([text], { type: 'text/plain' });
+  triggerDownload(blob, filename);
+}
+
+export function downloadJSON(filename, data) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  triggerDownload(blob, filename);
+}
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function loadText() {
+  return new Promise(resolve => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'text/plain';
+    input.style.display = 'none';
+    document.body.appendChild(input);
+    input.onchange = e => {
+      const file = e.target.files[0];
+      if (!file) {
+        document.body.removeChild(input);
+        resolve(null);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = evt => {
+        document.body.removeChild(input);
+        resolve(evt.target.result);
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  });
+}
+
+export function loadJSON() {
+  return loadText().then(text => {
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- create `file.js` module for reusable File API helpers
- add Save/Load buttons in the main song editor
- add Save/Load buttons in advanced song editor
- allow sets to be saved/loaded individually

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb9c6664c832799010ed6157da88f