### PR TITLE
Fix default view when hash not set

### DIFF
--- a/src/hook/useURL.js
+++ b/src/hook/useURL.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import useLocalStorage from './useLocalStorage'
-import {KEY} from '../constants'
+import {KEY, STATE} from '../constants'
 
 
 export default function useURLParams() {
@@ -32,9 +32,11 @@ export default function useURLParams() {
     
     
     const handleURLChange = () => {
-      // Handle hash changes
+      // Handle hash changes.  If no hash is present
+      // default to the list view rather than clearing
+      // the stored state which would hide the UI.
       const hash = window.location.hash.slice(1);
-      setState(hash)
+      setState(hash || STATE.LIST)
       
       // Handle query string changes
       const queryString = window.location.search;


### PR DESCRIPTION
## Summary
- avoid clearing the UI when no URL hash exists

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533bbee1f48327a712886699902a73