### PR TITLE
Add vite-plugin-pwa

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.3"
+    "vite": "^7.0.3",
+    "vite-plugin-pwa": "^0.18.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,44 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      manifestFilename: 'site.webmanifest',
+      includeAssets: [
+        'favicon.svg',
+        'favicon.ico',
+        'apple-touch-icon.png',
+        'favicon-96x96.png',
+        'robots.txt',
+      ],
+      manifest: {
+        name: 'Livesheet',
+        short_name: 'Livesheet',
+        theme_color: '#ecdec3',
+        background_color: '#ecdec3',
+        display: 'standalone',
+        icons: [
+          {
+            src: '/web-app-manifest-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+            purpose: 'maskable',
+          },
+          {
+            src: '/web-app-manifest-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+            purpose: 'maskable',
+          },
+        ],
+      },
+    }),
+  ],
   resolve: {
     alias: {
       '@': '/src',


### PR DESCRIPTION
## Summary
- enable PWA support with vite-plugin-pwa
- declare vite-plugin-pwa dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ec2c71dfc8327913d65aea81649d4