### PR TITLE
Add Dexie service worker for offline PWA

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import '@/style/index.css'
 import App from '@/App.tsx'
 
@@ -8,3 +9,6 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>,
 )
+
+// register service worker for offline support
+registerSW({ immediate: true })

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,26 @@
+import { clientsClaim } from 'workbox-core'
+import { precacheAndRoute } from 'workbox-precaching'
+import { registerRoute } from 'workbox-routing'
+import { StaleWhileRevalidate } from 'workbox-strategies'
+import { ExpirationPlugin } from 'workbox-expiration'
+
+// injected by workbox with the list of assets to precache
+declare let self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<any> }
+
+self.skipWaiting()
+clientsClaim()
+precacheAndRoute(self.__WB_MANIFEST)
+
+// cache images at runtime
+registerRoute(
+  ({ request }) => request.destination === 'image',
+  new StaleWhileRevalidate({
+    cacheName: 'images',
+    plugins: [new ExpirationPlugin({ maxEntries: 50 })],
+  }),
+)
+
+// Dexie Cloud service worker for offline sync
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - script provided at build time
+importScripts('dexie-cloud-addon/dist/dexie-cloud-addon-sw.js')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
         'favicon-96x96.png',
         'robots.txt',
       ],
+      srcDir: 'src',
+      filename: 'sw.ts',
+      strategies: 'injectManifest',
       manifest: {
         name: 'Livesheet',
         short_name: 'Livesheet',


### PR DESCRIPTION
## Summary
- configure Vite PWA to use a custom service worker
- register service worker in the app
- implement `src/sw.ts` with workbox caching and Dexie Cloud support

## Testing
- `npm run lint` *(fails: cannot find ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ec51665388327bc57f573f6336c68