### PR TITLE
configure gh-pages base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     
-    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-title" content="Livesheet" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="site.webmanifest" />
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Livesheet</title>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "livesheet",
   "private": true,
   "version": "0.0.0",
+  "homepage": "https://fingerskier.github.io/livesheet",
   "type": "module",
   "scripts": {
     "predeploy": "npm run build",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,13 +3,13 @@
   "short_name": "Livesheet",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
@@ -17,5 +17,4 @@
   ],
   "theme_color": "#ecdec3",
   "background_color": "#ecdec3",
-  "display": "standalone"
-}
+  "display": "standalone"}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/livesheet/',
   plugins: [
     react(),
     VitePWA({
@@ -27,13 +28,13 @@ export default defineConfig({
         display: 'standalone',
         icons: [
           {
-            src: '/web-app-manifest-192x192.png',
+            src: 'web-app-manifest-192x192.png',
             sizes: '192x192',
             type: 'image/png',
             purpose: 'maskable',
           },
           {
-            src: '/web-app-manifest-512x512.png',
+            src: 'web-app-manifest-512x512.png',
             sizes: '512x512',
             type: 'image/png',
             purpose: 'maskable',


### PR DESCRIPTION
## Summary
- set `base` to `/livesheet/` in `vite.config.ts`
- use relative URLs for icons and manifest
- adjust PWA manifest icon paths
- add repository `homepage` for GitHub Pages

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ece0c087083279e0622d88f7ab9fc