### PR TITLE
feat: allow creating and editing sets

### DIFF
--- a/src/com/SetAdd.tsx
+++ b/src/com/SetAdd.tsx
@@ -1,3 +1,16 @@
+import SetEditor from './SetEditor'
+import { db, type SetSong } from '../lib/db'
+
 export default function SetAdd() {
-  return <p>Add Set</p>
+  async function handleSave(data: { name: string, songs: SetSong[] }) {
+    await db.open()
+    await db.sets.add({
+      id: crypto.randomUUID(),
+      name: data.name,
+      date: Date.now(),
+      songs: data.songs
+    })
+  }
+
+  return <SetEditor onSave={handleSave} />
 }

--- a/src/com/SetEdit.tsx
+++ b/src/com/SetEdit.tsx
@@ -1,3 +1,29 @@
+import { useEffect, useState } from 'react'
+import { useStateMachine } from 'ygdrassil'
+import SetEditor from './SetEditor'
+import { db, type Set, type SetSong } from '../lib/db'
+
 export default function SetEdit() {
-  return <p>Edit Set</p>
+  const { query } = useStateMachine()
+  const [record, setRecord] = useState<Set | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      if (!query.id) return
+      await db.open()
+      const found = await db.sets.get(query.id as string)
+      if (found) setRecord(found)
+    }
+    load()
+  }, [query.id])
+
+  async function handleSave(data: { name: string, songs: SetSong[] }) {
+    if (!record) return
+    await db.open()
+    await db.sets.put({ ...record, name: data.name, songs: data.songs })
+  }
+
+  if (!record) return <p>Select a set to edit.</p>
+
+  return <SetEditor initialSet={record} onSave={handleSave} />
 }

--- a/src/com/SetEditor.tsx
+++ b/src/com/SetEditor.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import { db, type Song, type Set, type SetSong } from '../lib/db'
+import songToHtml from '../lib/SongToHtml'
+import Icon from 'unicode-icons'
+
+export type SetSongState = {
+  id: string
+  name: string
+  arrangement: string
+  key: string
+  arrangements: string[]
+}
+
+type Props = {
+  initialSet?: Set | null
+  onSave: (data: { name: string, songs: SetSong[] }) => Promise<void>
+}
+
+export default function SetEditor({ initialSet = null, onSave }: Props) {
+  const [name, setName] = useState(initialSet?.name || '')
+  const [songs, setSongs] = useState<SetSongState[]>([])
+  const [allSongs, setAllSongs] = useState<Song[]>([])
+  const [addSongId, setAddSongId] = useState('')
+
+  useEffect(() => {
+    async function loadSongs() {
+      await db.open()
+      const list = await db.songs.toArray()
+      setAllSongs(list)
+    }
+    loadSongs()
+  }, [])
+
+  useEffect(() => {
+    async function loadSet() {
+      if (!initialSet) return
+      await db.open()
+      const items: SetSongState[] = []
+      for (const s of initialSet.songs) {
+        const song = await db.songs.get(s.songId)
+        if (song) {
+          const result = songToHtml(song.text)
+          const arrs = result.arrangements
+          items.push({
+            id: song.id,
+            name: song.name,
+            arrangement: s.arrangement || arrs[0] || '',
+            key: s.key || result.song.key || '',
+            arrangements: arrs
+          })
+        }
+      }
+      setSongs(items)
+      setName(initialSet.name)
+    }
+    loadSet()
+  }, [initialSet])
+
+  function updateSong(index: number, updates: Partial<SetSongState>) {
+    setSongs(list => list.map((s, i) => i === index ? { ...s, ...updates } : s))
+  }
+
+  function moveSong(index: number, dir: number) {
+    setSongs(list => {
+      const res = [...list]
+      const [item] = res.splice(index, 1)
+      res.splice(index + dir, 0, item)
+      return res
+    })
+  }
+
+  function removeSong(index: number) {
+    setSongs(list => list.filter((_, i) => i !== index))
+  }
+
+  function handleAddSong() {
+    if (!addSongId) return
+    const song = allSongs.find(s => s.id === addSongId)
+    if (!song) return
+    const result = songToHtml(song.text)
+    const arrs = result.arrangements
+    setSongs(list => [...list, {
+      id: song.id,
+      name: song.name,
+      arrangement: arrs[0] || '',
+      key: result.song.key || '',
+      arrangements: arrs
+    }])
+    setAddSongId('')
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    await onSave({
+      name,
+      songs: songs.map(s => ({ songId: s.id, arrangement: s.arrangement, key: s.key }))
+    })
+    setName('')
+    setSongs([])
+  }
+
+  return <form onSubmit={handleSubmit}>
+    <h2>Set</h2>
+    <label>Name <input value={name} onChange={e => setName(e.target.value)} /></label>
+    <div>
+      <select value={addSongId} onChange={e => setAddSongId(e.target.value)}>
+        <option value=''>Select song</option>
+        {allSongs.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+      </select>
+      <button type='button' onClick={handleAddSong}>{Icon.PLUS}</button>
+    </div>
+    <ul>
+      {songs.map((s, i) => <li key={s.id}>
+        {s.name}
+        <select value={s.arrangement} onChange={e => updateSong(i, { arrangement: e.target.value })}>
+          {s.arrangements.map(a => <option key={a} value={a}>{a}</option>)}
+        </select>
+        <input value={s.key} onChange={e => updateSong(i, { key: e.target.value })} />
+        <button type='button' disabled={i === 0} onClick={() => moveSong(i, -1)}>{Icon.ARROW.UP}</button>
+        <button type='button' disabled={i === songs.length - 1} onClick={() => moveSong(i, 1)}>{Icon.ARROW.DOWN}</button>
+        <button type='button' onClick={() => removeSong(i)}>{Icon.CROSS}</button>
+      </li>)}
+    </ul>
+    <button type='submit'>Save</button>
+  </form>
+}

--- a/src/com/Sets.tsx
+++ b/src/com/Sets.tsx
@@ -1,3 +1,27 @@
+import { useEffect, useState } from 'react'
+import { StateButton } from 'ygdrassil'
+import { db, type Set } from '../lib/db'
+import Icon from 'unicode-icons'
+
 export default function Sets() {
-  return <p>All Sets</p>
+  const [sets, setSets] = useState<Set[]>([])
+
+  useEffect(() => {
+    async function load() {
+      await db.open()
+      const list = await db.sets.toArray()
+      setSets(list)
+    }
+    load()
+  }, [])
+
+  return <div>
+    <h2>Sets</h2>
+    <StateButton to='set-add'>{Icon.PLUS}</StateButton>
+    <ul>
+      {sets.map(set => <li key={set.id}>
+        <StateButton to='set-edit' data={{ id: set.id }}>{set.name}</StateButton>
+      </li>)}
+    </ul>
+  </div>
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,11 +10,17 @@ export type Song = {
   text: string
 }
 
+export type SetSong = {
+  songId: string
+  arrangement: string
+  key: string
+}
+
 export type Set = {
   id: string      // UUID v4
   name: string
   date: number   // Unix ms
-  songs: Song[]   // list of song IDs
+  songs: SetSong[]
 }
 
 


### PR DESCRIPTION
## Summary
- support storing key and arrangement per song in a set
- add SetEditor component to assemble sets with reordering, key and arrangement tweaks
- implement pages to add, edit and list sets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error: Unexpected token <)*
- `npm run build` *(fails: Property 'PRINTER' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689628dcbc6c83278f8276d78a69d12b