### PR TITLE
feat: add basic set viewer navigation

### DIFF
--- a/src/com/SetView.tsx
+++ b/src/com/SetView.tsx
@@ -1,3 +1,108 @@
-export default function Live() {
-  return <p>Live Mode</p>
+import { useEffect, useState } from 'react'
+import { useStateMachine } from 'ygdrassil'
+import { db } from '../lib/db'
+import songToHtml from '@/lib/SongToHtml'
+import useLocalStore from '@/hook/useLocalStore'
+import Icon from 'unicode-icons'
+
+type ViewSong = {
+  id: string
+  name: string
+  html: string
 }
+
+export default function Live() {
+  const { query } = useStateMachine()
+  const [songs, setSongs] = useState<ViewSong[]>([])
+  const [index, setIndex] = useState(0)
+  const store = useLocalStore()
+
+  useEffect(() => {
+    async function load() {
+      if (!query.id) return
+      await db.open()
+      const set = await db.sets.get(query.id as string)
+      if (!set) return
+
+      const items: ViewSong[] = []
+      for (const s of set.songs) {
+        const song = await db.songs.get(s.songId)
+        if (!song) continue
+        let text = song.text
+        if (s.key) {
+          const nl = text.indexOf('\n')
+          if (nl === -1) {
+            text = text.replace(/\s*\[[^\]]+\]\s*$/, '') + ` [${s.key}]`
+          } else {
+            const first = text.slice(0, nl).replace(/\s*\[[^\]]+\]\s*$/, '')
+            text = `${first} [${s.key}]${text.slice(nl)}`
+          }
+        }
+        const res = songToHtml(text, s.arrangement)
+        items.push({ id: song.id, name: song.name, html: res.html })
+      }
+      setSongs(items)
+      setIndex(0)
+    }
+    load()
+  }, [query.id])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'PageDown') {
+        e.preventDefault()
+        setIndex(i => Math.min(i + 1, songs.length - 1))
+      } else if (e.key === 'PageUp') {
+        e.preventDefault()
+        setIndex(i => Math.max(i - 1, 0))
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [songs.length])
+
+  useEffect(() => {
+    const current = songs[index]
+    if (!current) return
+    const elements = document.querySelectorAll('.chord')
+    elements.forEach(el => {
+      if (store.showChords) {
+        el.classList.remove('hidden')
+      } else {
+        el.classList.add('hidden')
+      }
+    })
+    const chordEl = document.querySelector('.song-chords')
+    if (chordEl) {
+      if (store.showChordset) {
+        chordEl.classList.remove('hidden')
+      } else {
+        chordEl.classList.add('hidden')
+      }
+    }
+    const metaEl = document.querySelector('.song-meta')
+    if (metaEl) {
+      if (store.showMeta) {
+        metaEl.classList.remove('hidden')
+      } else {
+        metaEl.classList.add('hidden')
+      }
+    }
+  }, [songs, index, store.showChords, store.showChordset, store.showMeta])
+
+  if (!songs.length) return <p>Select a set to view.</p>
+
+  const current = songs[index]
+
+  return (
+    <div>
+      <h2>{current.name}</h2>
+      <div className='dont print'>
+        <button type='button' onClick={() => setIndex(i => Math.max(i - 1, 0))} disabled={index === 0}>{Icon.ARROW.LEFT}</button>
+        <button type='button' onClick={() => setIndex(i => Math.min(i + 1, songs.length - 1))} disabled={index === songs.length - 1}>{Icon.ARROW.RIGHT}</button>
+      </div>
+      <div dangerouslySetInnerHTML={{ __html: current.html }} />
+    </div>
+  )
+}
+

--- a/src/com/Sets.tsx
+++ b/src/com/Sets.tsx
@@ -20,7 +20,9 @@ export default function Sets() {
     <StateButton to='set-add'>{Icon.PLUS}</StateButton>
     <ul>
       {sets.map(set => <li key={set.id}>
-        <StateButton to='set-edit' data={{ id: set.id }}>{set.name}</StateButton>
+        {set.name}
+        <StateButton to='set-view' data={{ id: set.id }}>{Icon.EYE}</StateButton>
+        <StateButton to='set-edit' data={{ id: set.id }}>{Icon.PENCIL}</StateButton>
       </li>)}
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- add view and edit controls to each set entry
- implement set viewer to render songs with arrangement/key and navigate with buttons or PgUp/PgDn

## Testing
- `npm run lint` (fails: Unnecessary escape character, Unexpected any, etc.)
- `npm run build` (fails: Property 'PRINTER' does not exist, cannot find module '../../dexie-cloud.json', etc.)

------
https://chatgpt.com/codex/tasks/task_e_68962ed8cc308327be7ef68f60bfbe2e