### PR TITLE
feat: advance between songs with page keys

### DIFF
--- a/src/com/SetView.tsx
+++ b/src/com/SetView.tsx
@@ -50,16 +50,26 @@ export default function Live() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'PageDown') {
-        e.preventDefault()
-        setIndex(i => Math.min(i + 1, songs.length - 1))
+        const atBottom = window.innerHeight + window.scrollY >= document.body.scrollHeight - 2
+        if (atBottom) {
+          e.preventDefault()
+          setIndex(i => Math.min(i + 1, songs.length - 1))
+        }
       } else if (e.key === 'PageUp') {
-        e.preventDefault()
-        setIndex(i => Math.max(i - 1, 0))
+        const atTop = window.scrollY <= 0
+        if (atTop) {
+          e.preventDefault()
+          setIndex(i => Math.max(i - 1, 0))
+        }
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [songs.length])
+
+  useEffect(() => {
+    window.scrollTo({ top: 0 })
+  }, [index])
 
   useEffect(() => {
     const current = songs[index]


### PR DESCRIPTION
## Summary
- let PageDown go to the next song when already at the bottom
- let PageUp go to the previous song when already at the top
- reset scroll position when changing songs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Parsing error: Unexpected token < ... and other lint errors)*
- `npm run build` *(fails: Property 'PRINTER' does not exist ... Cannot find module '../../dexie-cloud.json')*

------
https://chatgpt.com/codex/tasks/task_e_6896362ec9a8832783aa5e5456bb546a