### PR TITLE
Require scroll edge for PageUp/PageDown song navigation

### DIFF
--- a/src/com/SetView.tsx
+++ b/src/com/SetView.tsx
@@ -50,16 +50,17 @@ export default function Live() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const scrollable = document.body.scrollHeight > window.innerHeight
       if (e.key === 'PageDown') {
         const atBottom = window.innerHeight + window.scrollY >= document.body.scrollHeight - 2
-        if (atBottom) {
+        if (scrollable && atBottom) {
           e.preventDefault()
           scrollTarget.current = 'top'
           setIndex(i => Math.min(i + 1, songs.length - 1))
         }
       } else if (e.key === 'PageUp') {
         const atTop = window.scrollY <= 0
-        if (atTop) {
+        if (scrollable && atTop) {
           e.preventDefault()
           scrollTarget.current = 'bottom'
           setIndex(i => Math.max(i - 1, 0))


### PR DESCRIPTION
## Summary
- Avoid paging songs unless the viewer can scroll and is already at the top or bottom

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 70 problems, 69 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68963b8645748327862273dba168b8c4