### PR TITLE
Enable PageUp/PageDown navigation in set view

### DIFF
--- a/src/com/SetView.tsx
+++ b/src/com/SetView.tsx
@@ -53,14 +53,14 @@ export default function Live() {
       const scrollable = document.body.scrollHeight > window.innerHeight
       if (e.key === 'PageDown') {
         const atBottom = window.innerHeight + window.scrollY >= document.body.scrollHeight - 2
-        if (scrollable && atBottom) {
+        if (!scrollable || atBottom) {
           e.preventDefault()
           scrollTarget.current = 'top'
           setIndex(i => Math.min(i + 1, songs.length - 1))
         }
       } else if (e.key === 'PageUp') {
         const atTop = window.scrollY <= 0
-        if (scrollable && atTop) {
+        if (!scrollable || atTop) {
           e.preventDefault()
           scrollTarget.current = 'bottom'
           setIndex(i => Math.max(i - 1, 0))


### PR DESCRIPTION
## Summary
- Allow PageUp/PageDown to move between songs when the viewport is at the top or bottom of a song
- Switch songs even when content doesn't overflow the viewport, keeping navigation consistent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 70 problems)*


------
https://chatgpt.com/codex/tasks/task_e_68963fea33fc83278861274cb37ce9f7