### PR TITLE
feat: share songs with QR codes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import SetEdit from '@/com/SetEdit'
 import Live from '@/com/SetView'
 import Settings from '@/com/Settings'
 import Song from '@/com/SongView'
+import Share from '@/com/Share'
+import ShareScan from '@/com/ShareScan'
 
 import '@/style/App.css'
 
@@ -81,6 +83,14 @@ export default function App() {
 
         <State name='set-view'>
           <Live />
+        </State>
+
+        <State name='share'>
+          <Share />
+        </State>
+
+        <State name='share-scan'>
+          <ShareScan />
         </State>
 
         <State name='settings'>

--- a/src/com/Navigation.tsx
+++ b/src/com/Navigation.tsx
@@ -7,6 +7,8 @@ export default function Navigation() {
     <StateButton to='song-add'>Add Song</StateButton>
     <StateButton to='sets'>All Sets</StateButton>
     <StateButton to='set-add'>Add Set</StateButton>
+    <StateButton to='share'>Share</StateButton>
+    <StateButton to='share-scan'>Scan</StateButton>
     <StateButton to='settings'>Settings</StateButton>
   </div>
 }

--- a/src/com/Share.tsx
+++ b/src/com/Share.tsx
@@ -1,0 +1,29 @@
+import {useEffect, useState} from 'react'
+import {db, type Song} from '@/lib/db'
+
+export default function Share() {
+  const [songs, setSongs] = useState<Song[]>([])
+  const [songId, setSongId] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      await db.open()
+      const list = await db.songs.toArray()
+      setSongs(list)
+    }
+    load()
+  }, [])
+
+  const song = songs.find(s => s.id === songId)
+  const data = song ? JSON.stringify(song) : ''
+  const url = song ? `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(data)}` : ''
+
+  return <div>
+    <h2>Share Song</h2>
+    <select value={songId} onChange={e => setSongId(e.target.value)}>
+      <option value=''>Select a song</option>
+      {songs.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+    </select>
+    {url && <div><img src={url} alt='QR Code' /></div>}
+  </div>
+}

--- a/src/com/ShareScan.tsx
+++ b/src/com/ShareScan.tsx
@@ -1,0 +1,66 @@
+import {useEffect, useRef, useState} from 'react'
+import {db, type Song} from '@/lib/db'
+
+export default function ShareScan() {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    let stream: MediaStream
+    let active = true
+
+    async function start() {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream
+          await videoRef.current.play()
+        }
+        if ('BarcodeDetector' in window) {
+          const detector = new (window as any).BarcodeDetector({ formats: ['qr_code'] })
+          async function scan() {
+            if (!active || !videoRef.current) return
+            try {
+              const codes = await detector.detect(videoRef.current)
+              if (codes.length) {
+                const raw = codes[0].rawValue
+                if (raw) {
+                  active = false
+                  try {
+                    const song: Song = JSON.parse(raw)
+                    await db.open()
+                    await db.songs.put(song)
+                    setMessage(`Added song: ${song.name}`)
+                  } catch {
+                    setMessage('Invalid QR code')
+                  }
+                  stream.getTracks().forEach(t => t.stop())
+                  return
+                }
+              }
+            } catch {
+              // ignore
+            }
+            requestAnimationFrame(scan)
+          }
+          requestAnimationFrame(scan)
+        } else {
+          setMessage('Barcode detector not supported')
+        }
+      } catch {
+        setMessage('Camera unavailable')
+      }
+    }
+    start()
+    return () => {
+      active = false
+      if (stream) stream.getTracks().forEach(t => t.stop())
+    }
+  }, [])
+
+  return <div>
+    <h2>Scan Song</h2>
+    <video ref={videoRef} className='qr-video' />
+    {message && <p>{message}</p>}
+  </div>
+}


### PR DESCRIPTION
## Summary
- add share state that generates QR code for selected song
- add scanner state to read QR code and import song
- wire new share and scan pages into navigation and state machine

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: unexpected tokens in bak and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a2131be2483278fd9c2cf6037918a