### PR TITLE
feat: generate QR codes locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "dexie": "^4.0.11",
         "dexie-cloud-addon": "^4.0.12",
         "gh-pages": "^6.3.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-confection": "^4.0.0",
         "react-dom": "^19.1.0",
@@ -6285,6 +6286,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dexie": "^4.0.11",
     "dexie-cloud-addon": "^4.0.12",
     "gh-pages": "^6.3.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-confection": "^4.0.0",
     "react-dom": "^19.1.0",

--- a/src/com/Share.tsx
+++ b/src/com/Share.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react'
 import {db, type Song} from '@/lib/db'
+import {QRCodeSVG} from 'qrcode.react'
 
 export default function Share() {
   const [songs, setSongs] = useState<Song[]>([])
@@ -16,7 +17,6 @@ export default function Share() {
 
   const song = songs.find(s => s.id === songId)
   const data = song ? JSON.stringify(song) : ''
-  const url = song ? `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(data)}` : ''
 
   return <div>
     <h2>Share Song</h2>
@@ -24,6 +24,6 @@ export default function Share() {
       <option value=''>Select a song</option>
       {songs.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
     </select>
-    {url && <div><img src={url} alt='QR Code' /></div>}
+    {data && <div><QRCodeSVG value={data} size={200} /></div>}
   </div>
 }


### PR DESCRIPTION
## Summary
- replace external qrserver API usage with local `qrcode.react` component
- add `qrcode.react` dependency for local QR code generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: Unexpected token < and other eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a2973b7748327852c20a7bf6a7919